### PR TITLE
chore(deps): bump node from 14.15.0-alpine3.12 to 15.4.0-alpine3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.0-alpine3.12 AS builder
+FROM node:15.4.0-alpine3.12 AS builder
 
 LABEL org.opencontainers.image.source="https://github.com/jef/streetmerchant"
 
@@ -15,7 +15,7 @@ COPY src/ src/
 RUN npm run build
 RUN npm prune --production
 
-FROM node:14.15.0-alpine3.12
+FROM node:15.4.0-alpine3.12
 
 RUN apk add --no-cache chromium
 


### PR DESCRIPTION
Bumps node from 14.15.0-alpine3.12 to 15.4.0-alpine3.12.

Signed-off-by: dependabot[bot] <support@github.com>

<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
